### PR TITLE
Increase REST API read timeout from 10s to 60s to reduce failures on "c:..." queries

### DIFF
--- a/src/main/java/nz/ac/wgtn/shadedetector/MvnRestAPIClient.java
+++ b/src/main/java/nz/ac/wgtn/shadedetector/MvnRestAPIClient.java
@@ -5,6 +5,7 @@ import com.google.common.io.CharStreams;
 import okhttp3.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.concurrent.TimeUnit;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -53,7 +54,8 @@ public class MvnRestAPIClient {
             return cached;
         }
 
-        OkHttpClient client = new OkHttpClient();
+        // The default timeout of 10s is often much too short for "c:..." queries to https://search.maven.org/solrsearch/select
+        OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
         LOGGER.info("fetching data (attempt {}): GET {}",attempt,url);
         Request request = new Request.Builder().url(url).build();
         Call call = client.newCall(request);


### PR DESCRIPTION
A simple hardcoded fix. From quickly scanning the log output when running on `CVE-2016-6798`, it fixes the issue.

Before this fix, I saw a query failure that took 23 seconds to answer successfully:

```
C:\Users\walto\Documents\veracity>curl -o results.json "https://search.maven.org/solrsearch/select?q=c%3APlainTextToHtmlContentContext&wt=json&rows=200&start=1"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 82575    0 82575    0     0   3512      0 --:--:--  0:00:23 --:--:-- 19525
```