### PR TITLE
Fix CVE-2018-8017 run exiting early due to pom.xml/pov-project.json disagreement

### DIFF
--- a/src/main/java/nz/ac/wgtn/shadedetector/Main.java
+++ b/src/main/java/nz/ac/wgtn/shadedetector/Main.java
@@ -154,11 +154,14 @@ public class Main {
                 // Here we assume it's the only dependency with matching groupId and artifactId mentioned in pom.xml.
                 try {
                     List<MVNDependency> possibleArtifactsUnderTest = POMAnalysis.getMatchingDependencies(verificationProjectTemplateFolder.resolve("pom.xml").toFile(), dep -> dep.getGroupId().equals(groupIdFromMetadata) && dep.getArtifactId().equals(artifactIdFromMetadata));
+                    String versionFromMetadata = null;
                     if (possibleArtifactsUnderTest.size() != 1) {
                         LOGGER.error("Found {} dependency artifacts in PoV matching {}:{}, was expecting 1", possibleArtifactsUnderTest.size(), groupIdFromMetadata, artifactIdFromMetadata);
-                        System.exit(1);
+                        // Fall through. version will remain null unless specified by user with -v
                     }
-                    String versionFromMetadata = possibleArtifactsUnderTest.get(0).getVersion();
+                    else {
+                        versionFromMetadata = possibleArtifactsUnderTest.get(0).getVersion();
+                    }
                     groupId = groupIdFromMetadata;
                     artifactId = artifactIdFromMetadata;
                     version = versionFromMetadata;


### PR DESCRIPTION
Don't exit early if `pov-project.json` names an artifact that does not appear in `pom.xml`, provided that the user specifies the right details on the command line with `-g`, `-a`, `-v`.

Caught this only because I happened to run `shadedetector` against an `xshady` repo that I hadn't yet updated to get https://github.com/jensdietrich/xshady/pull/21. The command terminated early due to incorrect info in `pov-project.json`, even though that shouldn't have mattered since the correct data was specified on the command line.