### PR TITLE
Determine number of batches automatically from first REST API response

### DIFF
--- a/src/main/java/nz/ac/wgtn/shadedetector/Main.java
+++ b/src/main/java/nz/ac/wgtn/shadedetector/Main.java
@@ -240,7 +240,7 @@ public class Main {
         Artifact artifact = null;
         try {
             // note: fetching artifacts for all versions could be postponed
-            ArtifactSearchResponse response = ArtifactSearch.findVersions(groupId,artifactId,1,ArtifactSearch.ROWS_PER_BATCH);
+            ArtifactSearchResponse response = ArtifactSearch.findVersions(groupId,artifactId);
             allVersions = response.getBody().getArtifacts();
             final String finalVersion = version;    // To make the compiler happy compiling a lambda
             artifact = allVersions.stream()


### PR DESCRIPTION
Fixes #21.

Log snippet from `nohup time java -jar target/shadedetector.jar -g com.alibaba -a fastjson -v 1.2.24 -vul ../xshady/CVE-2017-18349 -sig failure -l log113-CVE-2017-18349.log -vos /home/whitewa/code/shadedetector/vuln_staging -vov /home/whitewa/code/shadedetector/vuln_final --stats stats113-CVE-2017-18349.log -o1 csv.details?dir=results/details113-CVE-2017-18349 -o2 csv.summary?file=results/summary113-CVE-2017-18349.csv -cache /local/scratch/whitewa/shadedetector/.cache &`:

```
2023-09-17 18:02:52,636 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:138]    fetching batch 1/-1
2023-09-17 18:02:52,657 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:150]    search url: https://search.maven.org/solrsearch/select?q=g%3Acom.alibaba%20AND%20a%3Afastjson&core=gav&wt=json&rows=200&start=1
2023-09-17 18:02:56,767 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:162]    response code is: 200
2023-09-17 18:02:56,792 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:167]    caching data in /local/scratch/whitewa/shadedetector/.cache/artifacts-versions/com.alibaba:fastjson-1.json
2023-09-17 18:02:56,901 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:179]    discovered there are 331 results, so 2 batches needed
2023-09-17 18:02:56,901 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:138]    fetching batch 2/2
2023-09-17 18:02:56,902 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:150]    search url: https://search.maven.org/solrsearch/select?q=g%3Acom.alibaba%20AND%20a%3Afastjson&core=gav&wt=json&rows=200&start=201
2023-09-17 18:02:57,335 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:162]    response code is: 200
2023-09-17 18:02:57,336 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:167]    caching data in /local/scratch/whitewa/shadedetector/.cache/artifacts-versions/com.alibaba:fastjson-2.json
2023-09-17 18:02:57,360 INFO [main] n.a.w.s.ArtifactSearch [ArtifactSearch.java:94]     330 versions found of "com.alibaba:fastjson
```

Although it looks like there should be 331 results, not 330, that's not our fault -- the REST API does in fact return just 200 + 130 = 330 results:

```
[whitewa@piccolo /local/scratch/whitewa/shadedetector/.cache/artifacts-versions]$ jq .response.docs[].v /local/scratch/whitewa/shadedetector/.cache/artifacts-versions/com.alibaba:fastjson-1.json|wc -l
200
[whitewa@piccolo /local/scratch/whitewa/shadedetector/.cache/artifacts-versions]$ ^-1^-2
jq .response.docs[].v /local/scratch/whitewa/shadedetector/.cache/artifacts-versions/com.alibaba:fastjson-2.json|wc -l
130
```
