### PR TITLE
Grandfather in old subdir-based class caches

### DIFF
--- a/src/main/java/nz/ac/wgtn/shadedetector/ArtifactSearch.java
+++ b/src/main/java/nz/ac/wgtn/shadedetector/ArtifactSearch.java
@@ -159,7 +159,7 @@ public class ArtifactSearch {
                             .collect(Collectors.toList());
                     ArtifactSearchResponse result = ArtifactSearchResponseMerger.merge(results);
 
-                    Path tempFile = Files.createTempFile(CACHE_BY_CLASSNAME.toPath(), "tmpmerged.", "");
+                    Path tempFile = Files.createTempFile(CACHE_BY_CLASSNAME.toPath(), "tmpmerged.", ".json");
                     writeJson(tempFile, result);
 
                     // Atomically "rename" the temp file to the final file.


### PR DESCRIPTION
We have already spent a lot of time caching class search results into the previous subdir-based system -- avoid having to re-download all of that by grandfathering in those caches into the new, merged-file-based cache.