### PR TITLE
Add run scripts for running `shadedetector` with `make` using sensible parameters

### DIFF
--- a/tools/run_all.sh
+++ b/tools/run_all.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+mkdir results && cd results && /usr/bin/time make -j 4 -k --output-sync=target -f ../Makefile > run.out 2>&1

--- a/tools/run_all_smaller_batch_counts.sh
+++ b/tools/run_all_smaller_batch_counts.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+for b in 4 3 2 1
+do
+	echo "Running with -bc $b in "`realpath batchcount$b`
+	mkdir batchcount$b && cd batchcount$b && /usr/bin/time make -j 4 -k --output-sync=target -f ../Makefile EXTRA_FLAGS="-bc $b" > run_-bc_$b.out 2>&1
+	cd ~/code/shadedetector
+done


### PR DESCRIPTION
These should be run from the repo root directory. They create subdirectories with fixed names (either `results`, or `batchcount4` .. `batchcount1`) to hold all output.

To run in the background without getting killed due to `SIGHUP`, these should be run like so:

```
$ nohup tools/run_all.sh &
```
