### PR TITLE
Re-add original grype DB via LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/vulnerability-db*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/sca/grype-db/vulnerability-db_v5_2023-04-27T10:34:58Z_90b83c0144433f50a35f.tar.gz
+++ b/sca/grype-db/vulnerability-db_v5_2023-04-27T10:34:58Z_90b83c0144433f50a35f.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d38611f0d901258c624156a848fe6e96c06cad60387efe453b0a39339701385b
+size 44071334


### PR DESCRIPTION
This was originally added via LFS in 75366eb2432, but removed (possibly accidentally) in 72f43664bb2.

Also adding `.gitattributes` to record the LFS-ness.