### PR TITLE
Fix `SyncReleaseFolders`

### DIFF
--- a/src/main/java/nz/ac/wgtn/shadedetector/resultanalysis/SyncReleaseFolders.java
+++ b/src/main/java/nz/ac/wgtn/shadedetector/resultanalysis/SyncReleaseFolders.java
@@ -18,8 +18,8 @@ import java.util.stream.Stream;
 public class SyncReleaseFolders {
 
 
-    public static final boolean SIMULATE_REMOVAL = true ;
-    public static final boolean SIMULATE_ADDITION = true ;
+    public static boolean SIMULATE_REMOVAL = true ;
+    public static boolean SIMULATE_ADDITION = true ;
 
     /**
      *
@@ -28,11 +28,22 @@ public class SyncReleaseFolders {
      */
     public static void main (String[] args) throws Exception {
 
-        Preconditions.checkState(args.length==2,"two arguments required -- the original repo, and the one to sync (add/remove)");
+        int firstNonOptionArg;
+        for (firstNonOptionArg = 0; firstNonOptionArg < args.length && args[firstNonOptionArg].startsWith("--"); ++firstNonOptionArg) {
+            if (args[firstNonOptionArg].equals("--add")) {
+                SIMULATE_ADDITION = false;
+            } else if (args[firstNonOptionArg].equals("--remove")) {
+                SIMULATE_REMOVAL = false;
+            } else {
+                throw new IllegalArgumentException("Unknown option '" + args[firstNonOptionArg] + "'");
+            }
+        }
 
-        File repo1 = new File(args[0]);
+        Preconditions.checkState(args.length == firstNonOptionArg + 2,"two arguments required -- the original repo, and the one to sync (add/remove)");
+
+        File repo1 = new File(args[firstNonOptionArg]);
         Preconditions.checkState(repo1.exists());
-        File repo2 = new File(args[1]);
+        File repo2 = new File(args[firstNonOptionArg + 1]);
         Preconditions.checkState(repo2.exists());
 
         List<String> CVEs = Stream.of(repo2.listFiles())


### PR DESCRIPTION
As before, running with just 2 command-line arguments (dest and source dirs) will only tell you what directories would be copied. Now, supplying `--add` and/or `--remove` before the directories causes new directories to actually be copied across, and/or directories that no longer exist to be removed, respectively.

Also fixed a bug where the top-level `CVE-...` directory does not yet exist in the dest dir.

Used this with `--add` to copy newly found vulnerable artifacts from `vuln_final` in run 42 on `wtwhite-vuw-vm` into `xshady-prerelease`.