### PR TITLE
Fix OWASP Dependency-Check reports

### DIFF
--- a/sca/Makefile
+++ b/sca/Makefile
@@ -45,10 +45,12 @@ touch_existing_reports:
 	mv $(@D)/vulas-report.json $@
 	rm -f $(@D)/vulas-report.{x,ht}ml
 
+# Maven's Dependency Check can fail due to rate-limiting, in which case we effectively delete the file to enable easy rerunning.
 %/scan-results/dependency-check/dependency-check-report.json: %/pom.xml
 	@echo "Running OWASP Dependency Check to generate $@..."
 	mkdir -p $(@D)
 	-cd $* && mvn org.owasp:dependency-check-maven:8.2.1:check -Dformat=json -DprettyPrint=true -Dodc.outputDirectory=$(@D:$*/%=%)
+	( if [ `jq '.scanInfo.analysisExceptions|length' $@` -ne 0 ]; then mv $@ $@.FAILED_WITH_EXCEPTIONS; exit 1; fi )
 
 # Env vars turn off all online activity
 %/scan-results/grype/grype-report.json: %/pom.xml


### PR DESCRIPTION
`sca/Makefile` currently runs OWASP's `dependency-check` binary directly, just like `sca/run-owasp-dependencycheck.sh` does, but `run-owaspdependencycheck.sh` in `xshady-prerelease` was more recently changed to run the Maven plugin instead, which:

- seems to produce a lot more results, but
- can fail due to rate-limiting.

This PR updates the `Makefile` to run the Maven plugin, detect if there were any exceptions, and if so effectively remove the output file so that a future `make` run will attempt it again.