### PR TITLE
Add GHSA updater tool

### DIFF
--- a/tools/update_ghsa.sh
+++ b/tools/update_ghsa.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+if [ "$#" -lt 2 ]
+then
+	echo "Syntax: $0 existing_ghsa.json [cve/]g__a__v [[cve/]g__a__v ...] > updated_ghsa.json"
+	echo "Each cve/g__a__v should look like CVE-1234-5678/somegroup__someartifact__1.2.3"
+	echo "No attempt is made to handle a GA or GAV already existing in existing_ghsa.json."
+	exit 1
+fi
+
 EXISTING_GHSA="$1"
 shift
-ls -d "$@" | perl -lne 's|.*/||; ($g, $a, $v) = split /__/; print "{\"name\": \"$g:$a\", \"versions\": [\"$v\"]}"' | jq -s 'group_by(.name) | {"affected": [.[] | {"package": {"ecosystem": "Maven", "name": .[0].name}, "versions": [.[].versions[]]}]}' | jq -j -s '.[0] + {"affected": (.[0].affected + .[1].affected)}' "$EXISTING_GHSA" -
+
+ls -d "$@" |
+	perl -lne 's|.*/||; s|/$||; ($g, $a, $v) = split /__/; print "{\"name\": \"$g:$a\", \"versions\": [\"$v\"]}"' |
+	jq -s 'group_by(.name) | {"affected": [.[] | {"package": {"ecosystem": "Maven", "name": .[0].name}, "versions": [.[].versions[]]}]}' | 		# Group all versions with same groupId and artifactId
+	jq -j -s '.[0] + {"affected": (.[0].affected + .[1].affected)}' "$EXISTING_GHSA" -								# Merge into existing GHSA JSON


### PR DESCRIPTION
This shell script can take an existing [GHSA](https://github.com/advisories) JSON file, and add new entries to it based on the `g__a__v` directory names produced by `shadedetector`.

Leans hard on `jq`.