### PR TITLE
Add simple tool to compute average clone 'confidence' from stderr logs

### DIFF
--- a/tools/measure_cloniness_from_logs.sh
+++ b/tools/measure_cloniness_from_logs.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Redirect input from a log file to this command, or pipe a bunch of logfiles into it with cat.
+perl -lne 'print $1 if (/analysing whether artifact '"$1"' matches/ ... /analysing whether artifact /) && /confidence: (\S+)/' | jq -s '{sum: add, count: length, avg: (add / length)}'


### PR DESCRIPTION
Grovels through the logs, digging out `confidence: ` values logged by `ASTBasedCloneDetector`, and prints their average. This is quite a strict criterion.