### PR TITLE
Improve GHSA updating

### DIFF
--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -113,6 +113,8 @@ if (@ARGV && $ARGV =~ /^--/) {
 
 die "Valid modes: " . join(", ", @validModes) if !grep { $mode eq $_ } @validModes;
 
+my $paperUrl = "https://arxiv.org/pdf/2306.05534.pdf";
+
 my %versions;
 while (<>) {
 	if (my ($cve, $g, $a, $v, $result) = m!^.* tests in \S+/([^/]+)/(\S+?)__(\S+?)__(\S+?): .* -> vuln is (present|absent)$!) {
@@ -166,6 +168,9 @@ foreach my $cve (sort keys %versions) {
 	}
 
 	if ($mode eq '--output-json' && @affected) {
-		print '{"affected": [', join(", ", @affected), "]}\n";
+		my $modifiedTime = `date --iso-8601=seconds --utc | sed -e 's/+00:00/Z/'`;
+		chomp $modifiedTime;
+		my $cveUrl = "https://github.com/jensdietrich/xshady-release/tree/main/$cve";
+		print '{"modified": "' . $modifiedTime . '", "aliases": ["' . $cve . '"], "affected": [', join(", ", @affected), '], "references": [{"type": "EVIDENCE", "url": "' . $cveUrl . '"}, {"type": "WEB", "url": "' . $paperUrl . "\"}]}\n";
 	}
 }

--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -155,13 +155,12 @@ foreach my $cve (sort keys %versions) {
 			if (@events) {
 				my $package = '{"package": {"ecosystem": "Maven", "name": "' . "$g:$art" . '"}, ';
 				if ($someVersionWasFixed) {
-					$package .= '"ranges": [{"type": "ECOSYSTEM", "events": [' . join(", ", @events) . ']}]';
+					push @affected, $package . '"ranges": [{"type": "ECOSYSTEM", "events": [' . join(", ", @events) . ']}]}';
 				} else {
-					$package .= '"versions": [' . join(", ", map { "\"$_\"" } @vulnVersions) . ']';
+					# GitHub can't handle multiple versions in the "versions" array. Workaround: Make per-version affected packages (suggested by darakian: https://github.com/github/advisory-database/pull/2841#issuecomment-1787952423)
+					#$package .= '"versions": [' . join(", ", map { "\"$_\"" } @vulnVersions) . ']';
+					push @affected, map { $package . '"versions": [' . "\"$_\"]}" } @vulnVersions;
 				}
-
-				$package .= '}';
-				push @affected, $package;
 			}
 		}
 	}

--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+while (<>) {
+	if (my ($cve, $g, $a, $v, $result) = m!^.* tests in \S+/([^/]+)/(\S+?)__(\S+?)__(\S+?): .* -> vuln is (present|absent)$!) {
+		print join("\t", $cve, "$g:$a", $v, $result), "\n";
+	}
+}

--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -154,15 +154,13 @@ foreach my $cve (sort keys %versions) {
 				}
 			}
 
+			if (defined($vulnIntroduced)) {
+				push @events, '{"last_affected": "' . $sortedVersions[$#sortedVersions][0] . '"}';
+			}
+
 			if (@events) {
 				my $package = '{"package": {"ecosystem": "Maven", "name": "' . "$g:$art" . '"}, ';
-				if ($someVersionWasFixed) {
-					push @affected, $package . '"ranges": [{"type": "ECOSYSTEM", "events": [' . join(", ", @events) . ']}]}';
-				} else {
-					# GitHub can't handle multiple versions in the "versions" array. Workaround: Make per-version affected packages (suggested by darakian: https://github.com/github/advisory-database/pull/2841#issuecomment-1787952423)
-					#$package .= '"versions": [' . join(", ", map { "\"$_\"" } @vulnVersions) . ']';
-					push @affected, map { $package . '"versions": [' . "\"$_\"]}" } @vulnVersions;
-				}
+				push @affected, $package . '"ranges": [{"type": "ECOSYSTEM", "events": [' . join(", ", @events) . ']}]}';
 			}
 		}
 	}

--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -3,6 +3,107 @@
 use strict;
 use warnings;
 
+# Call with two refs to arrays of numbers.
+sub compareNatural($$);		# Forward declaration
+sub compareNatural($$) {
+	my ($x, $y) = @_;
+	if (!@$x) {
+		return !@$y ? 0 : -1;
+	}
+
+	return 1 if !@$y;
+
+	die "Non-numeric component '$x->[0]' seen!" if $x->[0] !~ /\A\d+\z/;
+	die "Non-numeric component '$y->[0]' seen!" if $y->[0] !~ /\A\d+\z/;
+
+	if ($x->[0] == $y->[0]) {
+		shift @$x;
+		shift @$y;
+		return compareNatural($x, $y);
+	}
+
+	return $x->[0] <=> $y->[0];
+}
+
+sub extractSimpleVersionArray($) {
+	my ($prefix) = $_[0] =~ /^([0-9.]+)/ or die "Could not extract a simple version prefix from '$_[0]'!";
+	return map { $_ + 0 } split /\./, $prefix;
+}
+
+sub getMavenMetadataXmlUrlFor($$) {
+	my ($g, $a) = @_;
+	$g =~ tr|.|/|;
+	return "https://repo1.maven.org/maven2/$g/$a/maven-metadata.xml";
+}
+
+
+# Heuristically check that maven-metadata.xml versions "look right", i.e., look like they're in the correct order, and die if not
+sub checkMavenMetadataVersionsAreSensiblyOrdered($) {
+	my ($mapVersionToPosition) = @_;
+	my @original;
+	foreach (each %$mapVersionToPosition) {
+		$original[$_->[0]] = extractSimpleVersionArray($_->[1]);
+	}
+
+	my @sorted = sort compareNatural @original;
+
+	for (my $i = 0; $i < @original; ++$i) {
+		die "Missing version info for position $i!" if !defined $original[$i];
+		my $o = join(".", @{$original[$i]});
+		my $s = join(".", @{$sorted[$i]});
+		die "Expected version #$i to be '$s' but saw '$o'!" if $o ne $s;
+	}
+}
+
+sub downloadMavenMetadataXml($$) {
+	my ($g, $a) = @_;
+	my $url = getMavenMetadataXmlUrlFor($g, $a);
+
+	#my @versions;
+	my %mapVersionToPosition;
+	my $i = 0;
+	local $_;
+	print STDERR "Downloading metadata $url for $g:$a...\n";		#DEBUG
+	foreach (`curl $url`) {
+		if (m|<version>(.*)</version>\s*$|) {
+			#push @versions, $1;
+			$mapVersionToPosition{$1} = $i++;
+		}
+	}
+	print STDERR "Extracted metadata on $i versions from $url for $g:$a...\n";		#DEBUG
+
+	checkMavenMetadataVersionsAreSensiblyOrdered(\%mapVersionToPosition);		# Dies if it "looks wrong"
+
+	#return @versions;
+	return \%mapVersionToPosition;
+}
+
+my %mavenMetadataXmlCache = ();
+sub getMavenMetadataXml($$) {
+	my ($g, $a) = @_;
+	if (!exists $mavenMetadataXmlCache{"$g:$a"}) {
+		$mavenMetadataXmlCache{"$g:$a"} = downloadMavenMetadataXml($g, $a);
+	}
+
+	return $mavenMetadataXmlCache{"$g:$a"};
+}
+
+sub positionInVersionList($$$) {
+	my ($g, $a, $v) = @_;
+	my $mapVersionToPosition = getMavenMetadataXml($g, $a);
+	die "Could not find Maven metadata for $g:$a!" if !defined $mapVersionToPosition;
+	my $pos = $mapVersionToPosition->{$v};
+	die "Could not find version $v in Maven metadata for $g:$a!" if !defined $pos;
+
+	return $pos;
+}
+
+sub compareByMavenMetadata($$$$) {
+	my ($g, $a, $v1, $v2) = @_;
+	return positionInVersionList($g, $a, $v1) <=> positionInVersionList($g, $a, $v2);
+}
+
+# Main program
 while (<>) {
 	if (my ($cve, $g, $a, $v, $result) = m!^.* tests in \S+/([^/]+)/(\S+?)__(\S+?)__(\S+?): .* -> vuln is (present|absent)$!) {
 		print join("\t", $cve, "$g:$a", $v, $result), "\n";

--- a/tools/extract_vuln_range.pl
+++ b/tools/extract_vuln_range.pl
@@ -43,14 +43,10 @@ sub checkMavenMetadataVersionsAreSensiblyOrdered($) {
 	my ($mapVersionToPosition) = @_;
 	my @original;
 	foreach (keys %$mapVersionToPosition) {
-		#print STDERR "EACH: " . join(",", @$_) . "\n";	#DEBUG
-		#print STDERR "EACH: $_\n";	#DEBUG
 		$original[$mapVersionToPosition->{$_}] = [ extractSimpleVersionArray($_) ];
 	}
 
-	print STDERR "\@original:\n", join("\n", map { join(".", @$_) } @original), "\n";	#DEBUG
 	my @sorted = sort compareNatural @original;
-	print STDERR "\@sorted:\n", join("\n", map { join(".", @$_) } @sorted), "\n";	#DEBUG
 
 	for (my $i = 0; $i < @original; ++$i) {
 		die "Missing version info for position $i!" if !defined $original[$i];
@@ -64,22 +60,21 @@ sub downloadMavenMetadataXml($$) {
 	my ($g, $a) = @_;
 	my $url = getMavenMetadataXmlUrlFor($g, $a);
 
-	#my @versions;
 	my %mapVersionToPosition;
 	my $i = 0;
 	local $_;
-	print STDERR "Downloading metadata $url for $g:$a...\n";		#DEBUG
+	print STDERR "Downloading metadata $url for $g:$a...\n";
 	foreach (`curl $url`) {
 		if (m|<version>(.*)</version>\s*$|) {
 			#push @versions, $1;
 			$mapVersionToPosition{$1} = $i++;
 		}
 	}
-	print STDERR "Extracted metadata on $i versions from $url for $g:$a...\n";		#DEBUG
+	print STDERR "Extracted metadata on $i versions from $url for $g:$a...\n";
 
 	checkMavenMetadataVersionsAreSensiblyOrdered(\%mapVersionToPosition);		# Dies if it "looks wrong"
+	print STDERR "Version order from $url for $g:$a 'looks right'.\n";
 
-	#return @versions;
 	return \%mapVersionToPosition;
 }
 
@@ -121,7 +116,6 @@ foreach my $cve (sort keys %versions) {
 	foreach my $g (sort keys %{$versions{$cve}}) {
 		foreach my $art (sort keys %{$versions{$cve}{$g}}) {
 			my @sortedVersions = sort { compareByMavenMetadata($g, $art, $a->[0], $b->[0]) } @{$versions{$cve}{$g}{$art}};
-			#my @sortedVersions = @{$versions{$cve}{$g}{$art}};		#DEBUG: First try without any sorting
 			foreach my $vAndResult (@sortedVersions) {
 				my ($v, $result) = @$vAndResult;
 				print join("\t", $cve, "$g:$art", $v, $result), "\n";

--- a/tools/update_ghsa.sh
+++ b/tools/update_ghsa.sh
@@ -2,8 +2,8 @@
 
 if [ "$#" -lt 2 ]
 then
-	echo "Syntax: $0 existing_ghsa.json [cve/]g__a__v [[cve/]g__a__v ...] > updated_ghsa.json"
-	echo "Each cve/g__a__v should look like CVE-1234-5678/somegroup__someartifact__1.2.3"
+	echo "Syntax: $0 existing_ghsa.json logfile.log [logfile.log ...] > updated_ghsa.json"
+	echo "There must be at least one logfile argument, and all must refer to the same CVE."
 	echo "No attempt is made to handle a GA or GAV already existing in existing_ghsa.json."
 	exit 1
 fi
@@ -11,13 +11,6 @@ fi
 EXISTING_GHSA="$1"
 shift
 
-# Remaining arguments are dirs that should all refer to the same CVE
-CVE="$(basename $(dirname $1))"
-
-NOW=`date --iso-8601=seconds --utc | sed -e 's/+00:00/Z/'`
-ls -d "$@" |
-	perl -lne 's|/$||; s|.*/||; ($g, $a, $v) = split /__/; print "{\"name\": \"$g:$a\", \"versions\": [\"$v\"]}"' |
-	# GitHub can't handle multiple versions per affected package; workaround per https://github.com/github/advisory-database/pull/2841#issuecomment-1787952423 is to make a separate affected package for each version
-	#jq -s 'group_by(.name) | {"affected": [.[] | {"package": {"ecosystem": "Maven", "name": .[0].name}, "versions": [.[].versions[]]}]}' | 		# Group all versions with same groupId and artifactId
-	jq -s '{"affected": [.[] | {"package": {"ecosystem": "Maven", "name": .name}, "versions": .versions}]}' | 
-	jq -j -s '.[0] + {"modified": "'"$NOW"'", "affected": (.[0].affected + .[1].affected), "references": (.[0].references + [{"type": "EVIDENCE", "url": "https://github.com/jensdietrich/xshady-release/tree/main/'"$CVE"'"}, {"type": "WEB", "url": "https://arxiv.org/pdf/2306.05534.pdf"}])}' "$EXISTING_GHSA" -								# Merge into existing GHSA JSON
+# Remaining arguments are log files that should all refer to the same CVE
+# Extract new JSON data from log files, merge them into the old JSON, and write to stdout.
+`dirname $0`/extract_vuln_range.pl "$@" | jq -j -s '.[0] + {"affected": (.[0].affected + .[1].affected), "modified": .[1].modified, "references": (.[0].references + .[1].references)}' "$EXISTING_GHSA" -


### PR DESCRIPTION
Resolves #80. `update_ghsa.sh` is now able to generate finished, updated GHSA JSON on stdout when given the original GHSA JSON and one or more `shadedetector` log files as arguments.

(Uses Perl, but using bash/jq would have been even more painful.)